### PR TITLE
Sprint3 - Some Adjustments Were Made to Ensure Healthy Testing on the Local Network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+*.pem

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,9 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
+        "@types/node": "^24.7.0",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
-        "@vitejs/plugin-basic-ssl": "^2.1.0",
         "@vitejs/plugin-react-swc": "^4.0.0",
         "eslint": "^9.33.0",
         "eslint-plugin-react-hooks": "^5.2.0",
@@ -1283,6 +1283,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "24.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.0.tgz",
+      "integrity": "sha512-IbKooQVqUBrlzWTi79E8Fw78l8k1RNtlDDNWsFZs7XonuQSJ8oNYfEeclhprUldXISRMLzBpILuKgPlIxm+/Yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.14.0"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.1.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
@@ -1559,19 +1569,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@vitejs/plugin-basic-ssl": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-2.1.0.tgz",
-      "integrity": "sha512-dOxxrhgyDIEUADhb/8OlV9JIqYLgos03YorAueTIeOUskLJSEsfwCByjbu98ctXitUN3znXKp0bYD/WHSudCeA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "peerDependencies": {
-        "vite": "^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@vitejs/plugin-react-swc": {
@@ -3348,6 +3345,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
+      "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "dev:network": "vite --host",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
@@ -20,9 +20,9 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@types/node": "^24.7.0",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
-    "@vitejs/plugin-basic-ssl": "^2.1.0",
     "@vitejs/plugin-react-swc": "^4.0.0",
     "eslint": "^9.33.0",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,27 +1,16 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
-import basicSsl from '@vitejs/plugin-basic-ssl'
+import fs from 'fs'
 
 export default defineConfig({
-  plugins: 
-  [
-    react(),
-    basicSsl()
+  plugins: [
+    react()
   ],
   server: {
-    proxy: {
-      '/api': {
-        target: 'http://localhost:5166',
-        changeOrigin: true,
-        secure: false,
-      },
-      '/hub': {
-        target: 'http://localhost:5166',
-        changeOrigin: true,
-        secure: false,
-        ws: true,
-      }
-    },
-    https: true,
+    host: '0.0.0.0', 
+    https: {
+      key: fs.readFileSync('./localhost+3-key.pem'),
+      cert: fs.readFileSync('./localhost+3.pem'),
+    }
   }
 })


### PR DESCRIPTION
This pull request updates the development server configuration to use a custom HTTPS setup and removes the dependency on the `@vitejs/plugin-basic-ssl` package. It also adds type definitions for Node.js to the development dependencies. The most important changes are grouped below:

Development server and HTTPS configuration:

* The Vite development server is now configured to use custom HTTPS certificates by reading the key and certificate files directly in `vite.config.ts`, instead of relying on the `@vitejs/plugin-basic-ssl` plugin. The server is also set to listen on all network interfaces (`host: '0.0.0.0'`).
* The `dev` script in `package.json` is updated to always use the `--host` flag, ensuring the server is accessible on all network interfaces.

Dependency management:

* The `@vitejs/plugin-basic-ssl` package is removed from the development dependencies in `package.json`, as it is no longer needed.
* The `@types/node` package is added to the development dependencies to provide Node.js type definitions, which are required for using the `fs` module in the Vite configuration.